### PR TITLE
[Feature] [SC-179831] Preliminary support for ranged downloads in SDK

### DIFF
--- a/.codegen/__init__.py.tmpl
+++ b/.codegen/__init__.py.tmpl
@@ -3,6 +3,7 @@ import databricks.sdk.dbutils as dbutils
 from databricks.sdk.credentials_provider import CredentialsStrategy
 
 from databricks.sdk.mixins.files import DbfsExt
+from databricks.sdk.mixins.files import FilesExt
 from databricks.sdk.mixins.compute import ClustersExt
 from databricks.sdk.mixins.workspace import WorkspaceExt
 from databricks.sdk.mixins.open_ai_client import ServingEndpointsExt
@@ -18,7 +19,7 @@ from typing import Optional
   "google_credentials" "google_service_account" }}
 
 {{- define "api" -}}
-  {{- $mixins := dict "ClustersAPI" "ClustersExt" "DbfsAPI" "DbfsExt" "WorkspaceAPI" "WorkspaceExt" "ServingEndpointsAPI" "ServingEndpointsExt" -}}
+  {{- $mixins := dict "ClustersAPI" "ClustersExt" "DbfsAPI" "DbfsExt" "FilesAPI" "FilesExt" "WorkspaceAPI" "WorkspaceExt" "ServingEndpointsAPI" "ServingEndpointsExt" -}}
   {{- $genApi := concat .PascalName "API" -}}
   {{- getOrDefault $mixins $genApi $genApi -}}
 {{- end -}}

--- a/databricks/sdk/__init__.py
+++ b/databricks/sdk/__init__.py
@@ -5,7 +5,7 @@ import databricks.sdk.dbutils as dbutils
 from databricks.sdk import azure
 from databricks.sdk.credentials_provider import CredentialsStrategy
 from databricks.sdk.mixins.compute import ClustersExt
-from databricks.sdk.mixins.files import DbfsExt
+from databricks.sdk.mixins.files import DbfsExt, FilesExt
 from databricks.sdk.mixins.open_ai_client import ServingEndpointsExt
 from databricks.sdk.mixins.workspace import WorkspaceExt
 from databricks.sdk.service.apps import AppsAPI
@@ -202,7 +202,7 @@ class WorkspaceClient:
         self._dbsql_permissions = DbsqlPermissionsAPI(self._api_client)
         self._experiments = ExperimentsAPI(self._api_client)
         self._external_locations = ExternalLocationsAPI(self._api_client)
-        self._files = FilesAPI(self._api_client)
+        self._files = FilesExt(self._api_client)
         self._functions = FunctionsAPI(self._api_client)
         self._genie = GenieAPI(self._api_client)
         self._git_credentials = GitCredentialsAPI(self._api_client)
@@ -408,7 +408,7 @@ class WorkspaceClient:
         return self._external_locations
 
     @property
-    def files(self) -> FilesAPI:
+    def files(self) -> FilesExt:
         """The Files API is a standard HTTP API that allows you to read, write, list, and delete files and directories by referring to their URI."""
         return self._files
 

--- a/databricks/sdk/mixins/files.py
+++ b/databricks/sdk/mixins/files.py
@@ -22,8 +22,8 @@ from ..service import files
 from ..service._internal import _escape_multi_segment_path_parameter
 from ..service.files import DownloadResponse
 
-_FILES_MIXIN_DEBUG_ENABLED = True
-_FILES_MIXIN_ENABLE_UNSUPPORTED_FEATURES = True
+_FILES_MIXIN_DEBUG_ENABLED = False
+_FILES_MIXIN_ENABLE_UNSUPPORTED_FEATURES = False
 
 if TYPE_CHECKING:
     from _typeshed import Self

--- a/databricks/sdk/mixins/files.py
+++ b/databricks/sdk/mixins/files.py
@@ -760,7 +760,7 @@ class SeekableDownloadBinaryIO(BufferedIOBase):
     def detach(self):
         raise UnsupportedOperation("Detaching from the buffer is not supported")
 
-    def read(self, __size = -1, /):
+    def read(self, __size = -1):
         # Read and return up to size bytes. If omitted, None, or Negative, data is read until EOF is reached
         # Empty bytes object returned if stream is EOF
         self._ensure_open_stream()
@@ -768,7 +768,7 @@ class SeekableDownloadBinaryIO(BufferedIOBase):
         self._current_pos_of_underlying_stream += len(out)
         return out
 
-    def read1(self, __size = ...):
+    def read1(self, __size = -1):
         # Read and return up to size bytes, with at most one read() system call
         self._ensure_open_stream()
         out = self._underlying_stream.read1(__size)
@@ -829,7 +829,7 @@ class SeekableDownloadBinaryIO(BufferedIOBase):
         self._current_pos_of_underlying_stream += len(out)
         return out
 
-    def seek(self, __offset, __whence = os.SEEK_SET, /):
+    def seek(self, __offset, __whence = os.SEEK_SET):
         """
         Change the stream position to the given byte offset, which may necessitate closing the existing client connection and opening a new one.
 

--- a/databricks/sdk/service/compute.py
+++ b/databricks/sdk/service/compute.py
@@ -7865,6 +7865,38 @@ class CommandExecutionAPI:
             attempt += 1
         raise TimeoutError(f'timed out after {timeout}: {status_message}')
 
+    def wait_context_status_command_execution_running(
+            self,
+            cluster_id: str,
+            context_id: str,
+            timeout=timedelta(minutes=20),
+            callback: Optional[Callable[[ContextStatusResponse], None]] = None) -> ContextStatusResponse:
+        deadline = time.time() + timeout.total_seconds()
+        target_states = (ContextStatus.RUNNING, )
+        failure_states = (ContextStatus.ERROR, )
+        status_message = 'polling...'
+        attempt = 1
+        while time.time() < deadline:
+            poll = self.context_status(cluster_id=cluster_id, context_id=context_id)
+            status = poll.status
+            status_message = f'current status: {status}'
+            if status in target_states:
+                return poll
+            if callback:
+                callback(poll)
+            if status in failure_states:
+                msg = f'failed to reach Running, got {status}: {status_message}'
+                raise OperationFailed(msg)
+            prefix = f"cluster_id={cluster_id}, context_id={context_id}"
+            sleep = attempt
+            if sleep > 10:
+                # sleep 10s max per attempt
+                sleep = 10
+            _LOG.debug(f'{prefix}: ({status}) {status_message} (sleeping ~{sleep}s)')
+            time.sleep(sleep + random.random())
+            attempt += 1
+        raise TimeoutError(f'timed out after {timeout}: {status_message}')
+
     def wait_command_status_command_execution_finished_or_error(
             self,
             cluster_id: str,
@@ -7889,38 +7921,6 @@ class CommandExecutionAPI:
                 msg = f'failed to reach Finished or Error, got {status}: {status_message}'
                 raise OperationFailed(msg)
             prefix = f"cluster_id={cluster_id}, command_id={command_id}, context_id={context_id}"
-            sleep = attempt
-            if sleep > 10:
-                # sleep 10s max per attempt
-                sleep = 10
-            _LOG.debug(f'{prefix}: ({status}) {status_message} (sleeping ~{sleep}s)')
-            time.sleep(sleep + random.random())
-            attempt += 1
-        raise TimeoutError(f'timed out after {timeout}: {status_message}')
-
-    def wait_context_status_command_execution_running(
-            self,
-            cluster_id: str,
-            context_id: str,
-            timeout=timedelta(minutes=20),
-            callback: Optional[Callable[[ContextStatusResponse], None]] = None) -> ContextStatusResponse:
-        deadline = time.time() + timeout.total_seconds()
-        target_states = (ContextStatus.RUNNING, )
-        failure_states = (ContextStatus.ERROR, )
-        status_message = 'polling...'
-        attempt = 1
-        while time.time() < deadline:
-            poll = self.context_status(cluster_id=cluster_id, context_id=context_id)
-            status = poll.status
-            status_message = f'current status: {status}'
-            if status in target_states:
-                return poll
-            if callback:
-                callback(poll)
-            if status in failure_states:
-                msg = f'failed to reach Running, got {status}: {status_message}'
-                raise OperationFailed(msg)
-            prefix = f"cluster_id={cluster_id}, context_id={context_id}"
             sleep = attempt
             if sleep > 10:
                 # sleep 10s max per attempt

--- a/databricks/sdk/service/pipelines.py
+++ b/databricks/sdk/service/pipelines.py
@@ -2122,37 +2122,6 @@ class PipelinesAPI:
     def __init__(self, api_client):
         self._api = api_client
 
-    def wait_get_pipeline_idle(
-            self,
-            pipeline_id: str,
-            timeout=timedelta(minutes=20),
-            callback: Optional[Callable[[GetPipelineResponse], None]] = None) -> GetPipelineResponse:
-        deadline = time.time() + timeout.total_seconds()
-        target_states = (PipelineState.IDLE, )
-        failure_states = (PipelineState.FAILED, )
-        status_message = 'polling...'
-        attempt = 1
-        while time.time() < deadline:
-            poll = self.get(pipeline_id=pipeline_id)
-            status = poll.state
-            status_message = poll.cause
-            if status in target_states:
-                return poll
-            if callback:
-                callback(poll)
-            if status in failure_states:
-                msg = f'failed to reach IDLE, got {status}: {status_message}'
-                raise OperationFailed(msg)
-            prefix = f"pipeline_id={pipeline_id}"
-            sleep = attempt
-            if sleep > 10:
-                # sleep 10s max per attempt
-                sleep = 10
-            _LOG.debug(f'{prefix}: ({status}) {status_message} (sleeping ~{sleep}s)')
-            time.sleep(sleep + random.random())
-            attempt += 1
-        raise TimeoutError(f'timed out after {timeout}: {status_message}')
-
     def wait_get_pipeline_running(
             self,
             pipeline_id: str,
@@ -2173,6 +2142,37 @@ class PipelinesAPI:
                 callback(poll)
             if status in failure_states:
                 msg = f'failed to reach RUNNING, got {status}: {status_message}'
+                raise OperationFailed(msg)
+            prefix = f"pipeline_id={pipeline_id}"
+            sleep = attempt
+            if sleep > 10:
+                # sleep 10s max per attempt
+                sleep = 10
+            _LOG.debug(f'{prefix}: ({status}) {status_message} (sleeping ~{sleep}s)')
+            time.sleep(sleep + random.random())
+            attempt += 1
+        raise TimeoutError(f'timed out after {timeout}: {status_message}')
+
+    def wait_get_pipeline_idle(
+            self,
+            pipeline_id: str,
+            timeout=timedelta(minutes=20),
+            callback: Optional[Callable[[GetPipelineResponse], None]] = None) -> GetPipelineResponse:
+        deadline = time.time() + timeout.total_seconds()
+        target_states = (PipelineState.IDLE, )
+        failure_states = (PipelineState.FAILED, )
+        status_message = 'polling...'
+        attempt = 1
+        while time.time() < deadline:
+            poll = self.get(pipeline_id=pipeline_id)
+            status = poll.state
+            status_message = poll.cause
+            if status in target_states:
+                return poll
+            if callback:
+                callback(poll)
+            if status in failure_states:
+                msg = f'failed to reach IDLE, got {status}: {status_message}'
                 raise OperationFailed(msg)
             prefix = f"pipeline_id={pipeline_id}"
             sleep = attempt

--- a/docs/workspace/files/files.rst
+++ b/docs/workspace/files/files.rst
@@ -2,7 +2,7 @@
 ==================
 .. currentmodule:: databricks.sdk.service.files
 
-.. py:class:: FilesAPI
+.. py:class:: FilesExt
 
     The Files API is a standard HTTP API that allows you to read, write, list, and delete files and
     directories by referring to their URI. The API makes working with file content as raw bytes easier and
@@ -60,16 +60,16 @@
         
         
 
-    .. py:method:: download(file_path: str) -> DownloadResponse
+    .. py:method:: download(file_path: str [, start_byte_offset: Optional[int], if_unmodified_since_timestamp: Optional[datetime]]) -> DownloadResponse
 
         Download a file.
-        
+
         Downloads a file of up to 5 GiB. The file contents are the response body. This is a standard HTTP file
         download, not a JSON RPC.
-        
+
         :param file_path: str
           The absolute path of the file.
-        
+
         :returns: :class:`DownloadResponse`
         
 


### PR DESCRIPTION
## Changes
- Adds a class that exposes a ranged download as a seekable BinaryIO stream
- The seekable stream will re-open any closed streams, accounting for _some_ faults and expected socket timeouts due to inactivity, etc. 

## Known issues
- [DECO-23875] results in the download being performed in full before the byte array is streamed. This will cause negative performance impacts with this PR until it is fixed. 
- Integration testing is possible via an adhoc script, will follow in a separate PR
- CI jobs are only run on the DB main fork; 

## Tests

- [✅] `make test` run locally
- [✅] `make fmt` applied
- [🔁] relevant integration tests applied. This'll be added in a separate PR merging onto this branch _for reasons_

See https://github.com/databricks/databricks-sdk-py/pull/807 for CI results

## Branch Model
- All PRs for this feature will be merged onto a common feature branch that will be merged to the main branch in one go. 
